### PR TITLE
feat: Log all arguments when first argument is not a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,33 +33,41 @@ logger.info([1, 2, 3]);
 
 Logging (and level of logging) is controlled by [`gulp-cli`][gulp-cli-url]
 
-#### logger.debug(msg)
+#### logger.debug(msg, ...args)
 
 Highest log level. Typically used for debugging purposes.
 
 If the first argument is a string, all arguments are passed to node's
 [`util.format()`][util-format-url] before being emitted.
 
-#### logger.info(msg)
+If the first argument is not a string, all arguments will be emitted directly.
+
+#### logger.info(msg, ...args)
 
 Standard log level. Typically used for user information.
 
 If the first argument is a string, all arguments are passed to node's
 [`util.format()`][util-format-url] before being emitted.
 
-#### logger.warn(msg)
+If the first argument is not a string, all arguments will be emitted directly.
+
+#### logger.warn(msg, ...args)
 
 Warning log level. Typically used for warnings.
 
 If the first argument is a string, all arguments are passed to node's
 [`util.format()`][util-format-url] before being emitted.
 
-#### logger.error(msg)
+If the first argument is not a string, all arguments will be emitted directly.
+
+#### logger.error(msg, ...args)
 
 Error log level. Typically used when things went horribly wrong.
 
 If the first argument is a string, all arguments are passed to node's
 [`util.format()`][util-format-url] before being emitted.
+
+If the first argument is not a string, all arguments will be emitted directly.
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,35 +2,43 @@
  * Highest log level. Typically used for debugging purposes.
  *
  * If the first argument is a string, all arguments are passed to node's util.format() before being emitted.
+ *
+ * If the first argument is not a string, all arguments will be emitted directly.
+ *
  * @param msg Message to log
- * @param args Arguments to format message with via util.format()
+ * @param args Additional arguments
  */
-export function debug(msg: string, ...args: any[]): void;
-export function debug(msg: any): void;
+export function debug(msg: any, ...args: any[]): void;
 /**
  * Standard log level. Typically used for user information.
  *
  * If the first argument is a string, all arguments are passed to node's util.format() before being emitted.
+ *
+ * If the first argument is not a string, all arguments will be emitted directly.
+ *
  * @param msg Message to log
- * @param args Arguments to format message with via util.format()
+ * @param args Additional arguments
  */
-export function info(msg: string, ...args: any[]): void;
-export function info(msg: any): void;
+export function info(msg: any, ...args: any[]): void;
 /**
  * Warning log level. Typically used for warnings.
  *
  * If the first argument is a string, all arguments are passed to node's util.format() before being emitted.
+ *
+ * If the first argument is not a string, all arguments will be emitted directly.
+ *
  * @param msg Message to log
- * @param args Arguments to format message with via util.format()
+ * @param args Additional arguments
  */
-export function warn(msg: string, ...args: any[]): void;
-export function warn(msg: any): void;
+export function warn(msg: any, ...args: any[]): void;
 /**
  * Error log level. Typically used when things went horribly wrong.
  *
  * If the first argument is a string, all arguments are passed to node's util.format() before being emitted.
+ *
+ * If the first argument is not a string, all arguments will be emitted directly.
+ *
  * @param msg Message to log
- * @param args Arguments to format message with via util.format()
+ * @param args Additional arguments
  */
-export function error(msg: string, ...args: any[]): void;
-export function error(msg: any): void;
+export function error(msg: any, ...args: any[]): void;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "nyc mocha --async-only"
   },
   "dependencies": {
-    "glogg": "^2.0.0"
+    "glogg": "^2.1.0"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/test/index.js
+++ b/test/index.js
@@ -83,4 +83,14 @@ describe('gulplog', function () {
 
     logger.info([1, 2, 3]);
   });
+
+  it('logs all arguments if first argument is not a string', function (done) {
+    logger.on('info', function (arg1, arg2) {
+      expect(arg1).toEqual([1, 2, 3]);
+      expect(arg2).toEqual([4, 5, 6]);
+      done();
+    });
+
+    logger.info([1, 2, 3], [4, 5, 6]);
+  });
 });


### PR DESCRIPTION
This ensures arguments aren't lost when logged without a string message. This would allow for gulplog to support logging symbols plus extra data.